### PR TITLE
Change octal literal to unicode escaped character

### DIFF
--- a/sanitizer-bundle.js
+++ b/sanitizer-bundle.js
@@ -1433,7 +1433,7 @@ var html = (function(html4) {
     'AMP': '&',
     'quot': '"',
     'apos': '\'',
-    'nbsp': '\240'
+    'nbsp': '\u00A0'
   };
 
   // Patterns for types of entity/character reference names.


### PR DESCRIPTION
Webpack fails when using Babel, with the following error:
`Octal literal in strict mode`

JSLint recommends using unicode escaped characters instead:
https://jslinterrors.com/dont-use-octal-a-use-instead

By doing so, webpack builds successfully.