### PR TITLE
whitelist the a[rel] attribute

### DIFF
--- a/sanitizer-bundle.js
+++ b/sanitizer-bundle.js
@@ -2433,6 +2433,7 @@ var html_sanitize = html['sanitize'];
 html4.ATTRIBS['*::style'] = 0;
 html4.ELEMENTS['style'] = 0;
 html4.ATTRIBS['a::target'] = 0;
+html4.ATTRIBS['a::rel'] = 0;
 html4.ELEMENTS['video'] = 0;
 html4.ATTRIBS['video::src'] = 0;
 html4.ATTRIBS['video::poster'] = 0;


### PR DESCRIPTION
I don't think the `rel` attribute can be used as attack vector, and preserve it is useful (especially for rel="nofollow")